### PR TITLE
Added missing repository section

### DIFF
--- a/docs/user/tutorial/quickstart/artifacts/pom.xml
+++ b/docs/user/tutorial/quickstart/artifacts/pom.xml
@@ -31,4 +31,12 @@
             <version>${geotools.version}</version>
         </dependency>
     </dependencies>
+    <repository>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+      <id>osgeo</id>
+      <name>Open Source Geospatial Foundation Repository</name>
+      <url>http://download.osgeo.org/webdav/geotools/</url>
+    </repository>
 </project>


### PR DESCRIPTION
The Quickstart Maven tutorial (userguide/tutorial/quickstart/maven.html) includes sections of this file in various places. In "Create a new project" step 7 an empty code box is displayed because the repository section, which is referenced from there, is missing.
